### PR TITLE
Vulkan optimisations

### DIFF
--- a/src/video/mem/mod.rs
+++ b/src/video/mem/mod.rs
@@ -492,11 +492,16 @@ impl MemDevice for VideoMem {
 
 #[inline]
 fn get_base_pixel(base: usize) -> usize {
-    // TODO: shift and mask these for a more efficient operation...
-    let tile_x = (base % 0x100) / 0x10;
-    let tile_y = base / 0x100;
+    const PIX_SHIFT: usize = 1;
+    const X_SHIFT: usize = 4;
+    const Y_SHIFT: usize = 8;
 
-    let pixel_row_num = (base / 2) % 8;
+    const PIX_MASK: usize = 0x7;
+    const X_MASK: usize = 0xF;
+
+    let pixel_row_num = (base >> PIX_SHIFT) & PIX_MASK;
+    let tile_x = (base >> X_SHIFT) & X_MASK;
+    let tile_y = base >> Y_SHIFT;
 
     // tile_x * 8 pixels across per tile
     // pixel_row_num * 8 pixels across per tile * 16 tiles per row

--- a/src/video/mem/mod.rs
+++ b/src/video/mem/mod.rs
@@ -31,7 +31,6 @@ use palette::{
 pub use patternmem::TileImage;
 pub use palette::PaletteBuffer;
 
-const TILE_SIZE: usize = 8;             // Width / Height of a tile in pixels.
 const TILE_DATA_WIDTH: usize = 16;      // Width of the tile data in tiles.
 const TILE_DATA_HEIGHT_GB: usize = 24;  // Height of the tile data in tiles for GB.
 const TILE_DATA_HEIGHT_CGB: usize = 48; // Height of the tile data in tiles for GB Color.
@@ -138,7 +137,6 @@ impl VideoMem {
         VideoMem {
             tile_mem:   TileAtlas::new(
                 (TILE_DATA_WIDTH, if cgb_mode {TILE_DATA_HEIGHT_CGB} else {TILE_DATA_HEIGHT_GB}),
-                TILE_SIZE
             ),
             tile_map_0: VertexGrid::new(device, (MAP_SIZE, MAP_SIZE), (VIEW_WIDTH, VIEW_HEIGHT)),
             tile_map_1: VertexGrid::new(device, (MAP_SIZE, MAP_SIZE), (VIEW_WIDTH, VIEW_HEIGHT)),

--- a/src/video/mem/mod.rs
+++ b/src/video/mem/mod.rs
@@ -104,21 +104,21 @@ impl LCDStatus {
 // Video memory layer
 pub struct VideoMem {
     // Raw tile mem and tile maps
-    tile_mem:   TileAtlas,
-    tile_map_0: VertexGrid,
-    tile_map_1: VertexGrid,
-    object_mem: ObjectMem,
+    tile_mem:           TileAtlas,
+    tile_map_0:         VertexGrid,
+    tile_map_1:         VertexGrid,
+    object_mem:         ObjectMem,
 
     // Flags / registers
-    lcd_control:    LCDControl,
-    pub lcd_status: LCDStatus,
-    scroll_y:       u8,
-    scroll_x:       u8,
-    lcdc_y:         u8,
-    ly_compare:     u8,
+    lcd_control:        LCDControl,
+    pub lcd_status:     LCDStatus,
+    scroll_y:           u8,
+    scroll_x:           u8,
+    lcdc_y:             u8,
+    ly_compare:         u8,
 
-    window_y:       u8,
-    window_x:       u8,
+    window_y:           u8,
+    window_x:           u8,
 
     palettes:           StaticPaletteMem,
 
@@ -128,37 +128,37 @@ pub struct VideoMem {
     vram_bank:          u8,
 
     // Misc
-    clear_colour:   Vector4<f32>,
-    cycle_count:    u32,
+    clear_colour:       Vector4<f32>,
+    cycle_count:        u32,
 }
 
 impl VideoMem {
     pub fn new(device: &Arc<Device>, palette: SGBPalette, cgb_mode: bool) -> Self {
         VideoMem {
-            tile_mem:   TileAtlas::new(
+            tile_mem:           TileAtlas::new(
                 (TILE_DATA_WIDTH, if cgb_mode {TILE_DATA_HEIGHT_CGB} else {TILE_DATA_HEIGHT_GB}),
             ),
-            tile_map_0: VertexGrid::new(device, (MAP_SIZE, MAP_SIZE), (VIEW_WIDTH, VIEW_HEIGHT)),
-            tile_map_1: VertexGrid::new(device, (MAP_SIZE, MAP_SIZE), (VIEW_WIDTH, VIEW_HEIGHT)),
-            object_mem: ObjectMem::new(device),
+            tile_map_0:         VertexGrid::new(device, (MAP_SIZE, MAP_SIZE), (VIEW_WIDTH, VIEW_HEIGHT)),
+            tile_map_1:         VertexGrid::new(device, (MAP_SIZE, MAP_SIZE), (VIEW_WIDTH, VIEW_HEIGHT)),
+            object_mem:         ObjectMem::new(device),
 
-            lcd_control:    LCDControl::ENABLE,
-            lcd_status:     LCDStatus::new(),
-            scroll_y:       0,
-            scroll_x:       0,
-            lcdc_y:         0,
-            ly_compare:     0,
+            lcd_control:        LCDControl::ENABLE,
+            lcd_status:         LCDStatus::new(),
+            scroll_y:           0,
+            scroll_x:           0,
+            lcdc_y:             0,
+            ly_compare:         0,
 
-            window_y:       0,
-            window_x:       0,
+            window_y:           0,
+            window_x:           0,
 
             palettes:           StaticPaletteMem::new(device, palette),
             cgb_mode:           cgb_mode,
             colour_palettes:    DynamicPaletteMem::new(device),
             vram_bank:          0,
 
-            clear_colour:   palette.get_colour_0(),
-            cycle_count:    0
+            clear_colour:       palette.get_colour_0(),
+            cycle_count:        0
         }
     }
     

--- a/src/video/mem/patternmem.rs
+++ b/src/video/mem/patternmem.rs
@@ -62,7 +62,7 @@ impl TileAtlas {
     pub fn set_pixel_lower_row(&mut self, loc: usize, row: u8) {
         for i in 0..8 {
             let bit = (row >> (7 - i)) & 1;
-            self.atlas[loc + i] = (self.atlas[loc + i] & 0b10) | bit;
+            self.atlas[loc + i] = (self.atlas[loc + i] & bit!(1)) | bit;
         }
 
         self.image = None;
@@ -73,7 +73,7 @@ impl TileAtlas {
     pub fn set_pixel_upper_row(&mut self, loc: usize, row: u8) {
         for i in 0..8 {
             let bit = (row >> (7 - i)) & 1;
-            self.atlas[loc + i] = (self.atlas[loc + i] & 0b01) | (bit << 1);
+            self.atlas[loc + i] = (self.atlas[loc + i] & bit!(0)) | (bit << 1);
         }
 
         self.image = None;
@@ -82,7 +82,7 @@ impl TileAtlas {
     // Read a pixel row from the atlas.
     pub fn get_pixel_lower_row(&self, loc: usize) -> u8 {
         (0..8).fold(0, |acc, i| {
-            let bit = self.atlas[loc + i] & 0b01;
+            let bit = self.atlas[loc + i] & bit!(0);
             let shift = 7 - i;
             acc | (bit << shift)
         })
@@ -90,7 +90,7 @@ impl TileAtlas {
 
     pub fn get_pixel_upper_row(&self, loc: usize) -> u8 {
         (0..8).fold(0, |acc, i| {
-            let bit = (self.atlas[loc + i] & 0b10) >> 1;
+            let bit = (self.atlas[loc + i] & bit!(1)) >> 1;
             let shift = 7 - i;
             acc | (bit << shift)
         })

--- a/src/video/mem/patternmem.rs
+++ b/src/video/mem/patternmem.rs
@@ -31,25 +31,26 @@ use vulkano::{
 
 use std::sync::Arc;
 
+const TEX_WIDTH: usize = 8;                     // Width of a tile in pixels.
+const TEX_HEIGHT: usize = 8;                    // Height of a tile in pixels.
+const TEX_AREA: usize = TEX_WIDTH * TEX_HEIGHT; // Area of a tile in total number of pixels.
+
 pub type TileImage = Arc<ImmutableImage<R8Uint>>;
 pub type TileFuture = Box<dyn GpuFuture>;
 
 pub struct TileAtlas {
-    atlas:      Vec<u8>,        // formatted atlas of tiles
-    atlas_size: (usize, usize), // width/height of texture in tiles
-    tex_size:   usize,          // width/height of tile in texels
+    atlas:      Vec<u8>,            // formatted atlas of tiles
+    atlas_size: (usize, usize),     // width/height of texture in tiles
     
-    image:      Option<TileImage>
+    image:      Option<TileImage>   // cached images
 }
 
 impl TileAtlas {
-    pub fn new(atlas_size: (usize, usize), tex_size: usize) -> Self {
-        let tex_area = tex_size * tex_size;
-        let atlas_area = (atlas_size.0 * atlas_size.1) * tex_area;
+    pub fn new(atlas_size: (usize, usize)) -> Self {
+        let atlas_area = (atlas_size.0 * atlas_size.1) * TEX_AREA;
         TileAtlas {
             atlas:      vec![0; atlas_area],
             atlas_size: atlas_size,
-            tex_size:   tex_size,
 
             image:      None,
         }
@@ -100,8 +101,8 @@ impl TileAtlas {
         if let Some(image) = &self.image {
             (image.clone(), Box::new(now(device.clone())))
         } else {
-            let width = (self.atlas_size.0 * self.tex_size) as u32;
-            let height = (self.atlas_size.1 * self.tex_size) as u32;
+            let width = (self.atlas_size.0 * TEX_WIDTH) as u32;
+            let height = (self.atlas_size.1 * TEX_HEIGHT) as u32;
 
             let (image, future) = ImmutableImage::from_iter(
                 self.atlas.clone().into_iter(),

--- a/src/video/vulkan/renderer.rs
+++ b/src/video/vulkan/renderer.rs
@@ -102,21 +102,21 @@ struct RenderData {
 
 pub struct VulkanRenderer {
     // Core
-    device: Arc<Device>,
-    queue: Arc<Queue>,
-    pipeline: Arc<RenderPipeline>,
-    render_pass: Arc<dyn RenderPassAbstract + Send + Sync>,
-    surface: Arc<Surface<Window>>,
+    device:         Arc<Device>,
+    queue:          Arc<Queue>,
+    pipeline:       Arc<RenderPipeline>,
+    render_pass:    Arc<dyn RenderPassAbstract + Send + Sync>,
+    surface:        Arc<Surface<Window>>,
     // Uniforms
-    sampler: Arc<Sampler>,
-    set_pools: Vec<FixedSizeDescriptorSetsPool<Arc<RenderPipeline>>>,
+    sampler:        Arc<Sampler>,
+    set_pools:      Vec<FixedSizeDescriptorSetsPool<Arc<RenderPipeline>>>,
     // Vulkan data
-    swapchain: Arc<Swapchain<Window>>,
-    framebuffers: Vec<Arc<dyn FramebufferAbstract + Send + Sync>>,
-    dynamic_state: DynamicState,
+    swapchain:      Arc<Swapchain<Window>>,
+    framebuffers:   Vec<Arc<dyn FramebufferAbstract + Send + Sync>>,
+    dynamic_state:  DynamicState,
     // Frame data
-    previous_frame_future: Box<dyn GpuFuture>,
-    render_data: Option<RenderData>
+    previous_frame_future:  Box<dyn GpuFuture>,
+    render_data:            Option<RenderData>
 }
 
 impl VulkanRenderer {
@@ -254,21 +254,21 @@ impl VulkanRenderer {
         ];
 
         Box::new(VulkanRenderer {
-            device: device.clone(),
-            queue: queue,
-            pipeline: pipeline,
-            render_pass: render_pass,
-            surface: surface,
+            device:         device.clone(),
+            queue:          queue,
+            pipeline:       pipeline,
+            render_pass:    render_pass,
+            surface:        surface,
 
-            sampler: sampler,
-            set_pools: set_pools,
+            sampler:        sampler,
+            set_pools:      set_pools,
 
-            swapchain: swapchain,
-            framebuffers: framebuffers,
-            dynamic_state: dynamic_state,
+            swapchain:      swapchain,
+            framebuffers:   framebuffers,
+            dynamic_state:  dynamic_state,
 
-            previous_frame_future: Box::new(now(device.clone())),
-            render_data: None
+            previous_frame_future:  Box::new(now(device.clone())),
+            render_data:            None
         })
     }
 

--- a/src/video/vulkan/renderer.rs
+++ b/src/video/vulkan/renderer.rs
@@ -316,8 +316,7 @@ impl Renderer for VulkanRenderer {
         let (image_num, acquire_future) = acquire_next_image(self.swapchain.clone(), None)
             .expect("Didn't get next image");
 
-        // Make image with current texture.
-        // TODO: only re-create the image when the data has changed.
+        // Get image with current texture.
         let (image, write_future) = video_mem.get_tile_atlas(&self.device, &self.queue);
 
         // Make descriptor set to bind texture atlas.


### PR DESCRIPTION
Various vulkan optimisations and cleanup.

Mainly:
- Tile map buffers are cached and re-used if not changed, and the code is a little cleaner.
- Sprite vertex creation allocates way less vectors than before.

But also:
- Tile size was made into a constant (it's always 8)
- Getting the base pixel to use for pattern mem is cleaned up and maybe quicker
- Loads of spacing and const cleanups.