### PR TITLE
Separate Vulkano code from video memory

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -45,8 +45,7 @@ fn main() {
     let palette = choose_palette(cmd_args.value_of("palette"));
 
     let mut events_loop = EventsLoop::new();
-    let renderer = VulkanRenderer::new(WindowType::Winit(&events_loop));
-    let mut rustboy = RustBoy::new(&cart, &save_file, palette, cmd_args.is_present("mute"), renderer);
+    let mut rustboy = RustBoy::new(&cart, &save_file, palette, cmd_args.is_present("mute"), RendererType::Vulkano(&events_loop));
 
     //let mut averager = avg::Averager::<i64>::new(60);
     

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ pub mod debug;
 pub use video::{
     UserPalette,
     VulkanRenderer,
-    WindowType
+    RendererType
 };
 
 use joypad::{
@@ -50,7 +50,7 @@ pub struct RustBoy {
 }
 
 impl RustBoy {
-    pub fn new(cart_name: &str, save_file_name: &str, palette: UserPalette, mute: bool, renderer: Box<VulkanRenderer>) -> Box<Self> {
+    pub fn new(cart_name: &str, save_file_name: &str, palette: UserPalette, mute: bool, renderer: RendererType) -> Box<Self> {
         let (send, recv) = channel();
 
         let ad = AudioDevice::new(send);

--- a/src/mem/bus.rs
+++ b/src/mem/bus.rs
@@ -3,8 +3,8 @@
 use crate::{
     video::{
         sgbpalettes::*,
-        VideoDevice,
-        VulkanRenderer
+        RendererType,
+        VideoDevice
     },
     audio::AudioDevice,
     timer::Timer,
@@ -44,7 +44,7 @@ pub struct MemBus {
 }
 
 impl MemBus {
-    pub fn new(rom_file: &str, save_file: &str, user_palette: UserPalette, audio_device: AudioDevice, renderer: Box<VulkanRenderer>) -> MemBus {
+    pub fn new(rom_file: &str, save_file: &str, user_palette: UserPalette, audio_device: AudioDevice, renderer: RendererType) -> MemBus {
         let rom = match Cartridge::new(rom_file, save_file) {
             Ok(r) => r,
             Err(s) => panic!("Could not construct ROM: {}", s),

--- a/src/video/mem/consts.rs
+++ b/src/video/mem/consts.rs
@@ -1,0 +1,13 @@
+pub const TILE_DATA_WIDTH: usize = 16;      // Width of the tile data in tiles.
+pub const TILE_DATA_HEIGHT_GB: usize = 24;  // Height of the tile data in tiles for GB.
+pub const TILE_DATA_HEIGHT_CGB: usize = 48; // Height of the tile data in tiles for GB Color.
+pub const MAP_SIZE: usize = 32;             // Width / Height of bg/window tile maps.
+pub const VIEW_WIDTH: usize = 20;           // Width of visible area.
+pub const VIEW_HEIGHT: usize = 18;          // Height of visible area.
+
+pub const OFFSET_FRAC_X: f32 = (MAP_SIZE as f32 / VIEW_WIDTH as f32) / 128.0;   // Mult with an offset to get the amount to offset by
+pub const OFFSET_FRAC_Y: f32 = (MAP_SIZE as f32 / VIEW_HEIGHT as f32) / 128.0;  // Mult with an offset to get the amount to offset by
+
+pub const TEX_WIDTH: usize = 8;                     // Width of a tile in pixels.
+pub const TEX_HEIGHT: usize = 8;                    // Height of a tile in pixels.
+pub const TEX_AREA: usize = TEX_WIDTH * TEX_HEIGHT; // Area of a tile in total number of pixels.

--- a/src/video/mem/mod.rs
+++ b/src/video/mem/mod.rs
@@ -295,7 +295,12 @@ impl VideoMem {
     pub fn ref_sprites_lo<'a>(&'a mut self, y: u8) -> Option<&'a mut Vec<Vertex>> {
         if self.lcd_control.contains(LCDControl::OBJ_DISPLAY_ENABLE) {
             let large_sprites = self.lcd_control.contains(LCDControl::OBJ_SIZE);
-            Some(self.object_mem.get_lo_vertices(y, large_sprites, self.cgb_mode))
+            let vertices = self.object_mem.ref_lo_vertices(y, large_sprites, self.cgb_mode);
+            if !vertices.is_empty() {
+                Some(vertices)
+            } else {
+                None
+            }
         } else {
             None
         }
@@ -305,7 +310,12 @@ impl VideoMem {
     pub fn ref_sprites_hi<'a>(&'a mut self, y: u8) -> Option<&'a mut Vec<Vertex>> {
         if self.lcd_control.contains(LCDControl::OBJ_DISPLAY_ENABLE) {
             let large_sprites = self.lcd_control.contains(LCDControl::OBJ_SIZE);
-            Some(self.object_mem.get_hi_vertices(y, large_sprites, self.cgb_mode))
+            let vertices = self.object_mem.ref_hi_vertices(y, large_sprites, self.cgb_mode);
+            if !vertices.is_empty() {
+                Some(vertices)
+            } else {
+                None
+            }
         } else {
             None
         }

--- a/src/video/mem/mod.rs
+++ b/src/video/mem/mod.rs
@@ -52,6 +52,11 @@ bitflags! {
     }
 }
 
+pub enum TileMap {
+    _0,
+    _1
+}
+
 pub struct LCDStatus {
     flags: LCDStatusFlags,
     video_mode: super::Mode,
@@ -248,6 +253,24 @@ impl VideoMem {
         self.cgb_mode
     }
 
+    // Which tile map the background is using.
+    pub fn background_tile_map(&self) -> TileMap {
+        if self.lcd_control.contains(LCDControl::BG_TILE_MAP_SELECT) {
+            TileMap::_1
+        } else {
+            TileMap::_0
+        }
+    }
+
+    // Which tile map the window is using.
+    pub fn window_tile_map(&self) -> TileMap {
+        if self.lcd_control.contains(LCDControl::WINDOW_TILE_MAP_SELECT) {
+            TileMap::_1
+        } else {
+            TileMap::_0
+        }
+    }
+
     // Returns the raw tile atlas data (pattern memory). If None is returned, the data has not changed since last time.
     pub fn ref_tile_atlas<'a>(&'a mut self) -> Option<&'a [u8]> {
         if self.tile_mem.is_dirty() {
@@ -257,37 +280,21 @@ impl VideoMem {
         }
     }
 
-    // Get background vertices for given y line. If None is returned, the data has not changed since last time.
-    pub fn ref_background<'a>(&'a mut self, y: u8) -> Option<&'a [Vertex]> {
-        if !self.lcd_control.contains(LCDControl::BG_TILE_MAP_SELECT) {
-            if self.tile_map_0.is_dirty(y) {
-                Some(self.tile_map_0.ref_data(y))
-            } else {
-                None
-            }
+    // Get tile map 0 vertices for given y line. If None is returned, the data has not changed since last time.
+    pub fn ref_tile_map_0<'a>(&'a mut self, y: usize) -> Option<&'a [Vertex]> {
+        if self.tile_map_0.is_dirty(y) {
+            Some(self.tile_map_0.ref_data(y))
         } else {
-            if self.tile_map_1.is_dirty(y) {
-                Some(self.tile_map_1.ref_data(y))
-            } else {
-                None
-            }
+            None
         }
     }
 
-    // Get window vertices for given y line. If None is returned, the data has not changed since last time.
-    pub fn ref_window<'a>(&'a mut self, y: u8) -> Option<&'a [Vertex]> {
-        if !self.lcd_control.contains(LCDControl::WINDOW_TILE_MAP_SELECT) {
-            if self.tile_map_0.is_dirty(y) {
-                Some(self.tile_map_0.ref_data(y))
-            } else {
-                None
-            }
+    // Get tile map 1 vertices for given y line. If None is returned, the data has not changed since last time.
+    pub fn ref_tile_map_1<'a>(&'a mut self, y: usize) -> Option<&'a [Vertex]> {
+        if self.tile_map_1.is_dirty(y) {
+            Some(self.tile_map_1.ref_data(y))
         } else {
-            if self.tile_map_1.is_dirty(y) {
-                Some(self.tile_map_1.ref_data(y))
-            } else {
-                None
-            }
+            None
         }
     }
 

--- a/src/video/mem/mod.rs
+++ b/src/video/mem/mod.rs
@@ -52,11 +52,6 @@ bitflags! {
     }
 }
 
-pub enum TileMap {
-    _0,
-    _1
-}
-
 pub struct LCDStatus {
     flags: LCDStatusFlags,
     video_mode: super::Mode,
@@ -253,24 +248,6 @@ impl VideoMem {
         self.cgb_mode
     }
 
-    // Which tile map the background is using.
-    pub fn background_tile_map(&self) -> TileMap {
-        if self.lcd_control.contains(LCDControl::BG_TILE_MAP_SELECT) {
-            TileMap::_1
-        } else {
-            TileMap::_0
-        }
-    }
-
-    // Which tile map the window is using.
-    pub fn window_tile_map(&self) -> TileMap {
-        if self.lcd_control.contains(LCDControl::WINDOW_TILE_MAP_SELECT) {
-            TileMap::_1
-        } else {
-            TileMap::_0
-        }
-    }
-
     // Returns the raw tile atlas data (pattern memory). If None is returned, the data has not changed since last time.
     pub fn ref_tile_atlas<'a>(&'a mut self) -> Option<&'a [u8]> {
         if self.tile_mem.is_dirty() {
@@ -280,21 +257,37 @@ impl VideoMem {
         }
     }
 
-    // Get tile map 0 vertices for given y line. If None is returned, the data has not changed since last time.
-    pub fn ref_tile_map_0<'a>(&'a mut self, y: usize) -> Option<&'a [Vertex]> {
-        if self.tile_map_0.is_dirty(y) {
-            Some(self.tile_map_0.ref_data(y))
+    // Get background vertices for given y line. If None is returned, the data has not changed since last time.
+    pub fn ref_background<'a>(&'a mut self, y: usize) -> Option<&'a [Vertex]> {
+        if !self.lcd_control.contains(LCDControl::BG_TILE_MAP_SELECT) {
+            if self.tile_map_0.is_dirty_bg(y) {
+                Some(self.tile_map_0.ref_data_bg(y))
+            } else {
+                None
+            }
         } else {
-            None
+            if self.tile_map_1.is_dirty_bg(y) {
+                Some(self.tile_map_1.ref_data_bg(y))
+            } else {
+                None
+            }
         }
     }
 
-    // Get tile map 1 vertices for given y line. If None is returned, the data has not changed since last time.
-    pub fn ref_tile_map_1<'a>(&'a mut self, y: usize) -> Option<&'a [Vertex]> {
-        if self.tile_map_1.is_dirty(y) {
-            Some(self.tile_map_1.ref_data(y))
+    // Get window vertices for given y line. If None is returned, the data has not changed since last time.
+    pub fn ref_window<'a>(&'a mut self, y: usize) -> Option<&'a [Vertex]> {
+        if !self.lcd_control.contains(LCDControl::WINDOW_TILE_MAP_SELECT) {
+            if self.tile_map_0.is_dirty_window(y) {
+                Some(self.tile_map_0.ref_data_window(y))
+            } else {
+                None
+            }
         } else {
-            None
+            if self.tile_map_1.is_dirty_window(y) {
+                Some(self.tile_map_1.ref_data_window(y))
+            } else {
+                None
+            }
         }
     }
 

--- a/src/video/mem/mod.rs
+++ b/src/video/mem/mod.rs
@@ -292,7 +292,7 @@ impl VideoMem {
     }
 
     // Get low-priority sprites (below the background) for given y line.
-    pub fn ref_sprites_lo<'a>(&'a mut self, y: u8) -> Option<&'a [Vertex]> {
+    pub fn ref_sprites_lo<'a>(&'a mut self, y: u8) -> Option<&'a mut Vec<Vertex>> {
         if self.lcd_control.contains(LCDControl::OBJ_DISPLAY_ENABLE) {
             let large_sprites = self.lcd_control.contains(LCDControl::OBJ_SIZE);
             Some(self.object_mem.get_lo_vertices(y, large_sprites, self.cgb_mode))
@@ -302,7 +302,7 @@ impl VideoMem {
     }
 
     // Get high-priority sprites (above the background) for given y line.
-    pub fn ref_sprites_hi<'a>(&'a mut self, y: u8) -> Option<&'a [Vertex]> {
+    pub fn ref_sprites_hi<'a>(&'a mut self, y: u8) -> Option<&'a mut Vec<Vertex>> {
         if self.lcd_control.contains(LCDControl::OBJ_DISPLAY_ENABLE) {
             let large_sprites = self.lcd_control.contains(LCDControl::OBJ_SIZE);
             Some(self.object_mem.get_hi_vertices(y, large_sprites, self.cgb_mode))

--- a/src/video/mem/palette/dynamic.rs
+++ b/src/video/mem/palette/dynamic.rs
@@ -120,9 +120,6 @@ pub struct DynamicPaletteMem {
     obj_auto_inc:       PaletteIndex,
 
     dirty:              bool
-
-    //buffer_pool:        CpuBufferPool<PaletteColours>,
-    //current_buffer:     Option<PaletteBuffer>
 }
 
 impl DynamicPaletteMem {
@@ -137,29 +134,8 @@ impl DynamicPaletteMem {
             obj_auto_inc:       PaletteIndex::default(),
 
             dirty:              true
-
-            //buffer_pool:        CpuBufferPool::uniform_buffer(device.clone()),
-            //current_buffer:     None
         }
     }
-
-    /*pub fn get_buffer(&mut self) -> PaletteBuffer {
-        if let Some(buf) = &self.current_buffer {
-            buf.clone()
-        } else {
-            let buf = self.buffer_pool.chunk(
-                self.bg_palettes.iter()
-                    .map(|p| p.get_palette(true))
-                    .chain(self.bg_palettes.iter().map(|p| p.get_palette(false)))
-                    .chain(self.obj_palettes.iter().map(|p| p.get_palette(true)))
-                    .collect::<Vec<_>>()
-                    .iter()
-                    .cloned()
-            ).unwrap();
-            self.current_buffer = Some(buf.clone());
-            buf
-        }
-    }*/
 
     pub fn make_data(&mut self) -> Vec<PaletteColours> {
         self.dirty = false;

--- a/src/video/mem/palette/dynamic.rs
+++ b/src/video/mem/palette/dynamic.rs
@@ -1,10 +1,4 @@
 // Game Boy Color 15-bit palettes.
-
-use vulkano::{
-    buffer::CpuBufferPool,
-    device::Device
-};
-
 use cgmath::{
     Vector4,
     Matrix4
@@ -12,12 +6,9 @@ use cgmath::{
 
 use bitflags::bitflags;
 
-use std::sync::Arc;
-
-use crate::mem::MemDevice;
-use super::{
-    PaletteColours,
-    PaletteBuffer
+use crate::{
+    mem::MemDevice,
+    video::PaletteColours
 };
 
 const MAX_COLOUR: f32 = 0x1F as f32;
@@ -128,12 +119,14 @@ pub struct DynamicPaletteMem {
     obj_palette_index:  usize,
     obj_auto_inc:       PaletteIndex,
 
-    buffer_pool:        CpuBufferPool<PaletteColours>,
-    current_buffer:     Option<PaletteBuffer>
+    dirty:              bool
+
+    //buffer_pool:        CpuBufferPool<PaletteColours>,
+    //current_buffer:     Option<PaletteBuffer>
 }
 
 impl DynamicPaletteMem {
-    pub fn new(device: &Arc<Device>) -> Self {
+    pub fn new() -> Self {
         DynamicPaletteMem {
             bg_palettes:        vec![DynamicPalette::new(); 8],
             bg_palette_index:   0,
@@ -143,12 +136,14 @@ impl DynamicPaletteMem {
             obj_palette_index:  0,
             obj_auto_inc:       PaletteIndex::default(),
 
-            buffer_pool:        CpuBufferPool::uniform_buffer(device.clone()),
-            current_buffer:     None
+            dirty:              true
+
+            //buffer_pool:        CpuBufferPool::uniform_buffer(device.clone()),
+            //current_buffer:     None
         }
     }
 
-    pub fn get_buffer(&mut self) -> PaletteBuffer {
+    /*pub fn get_buffer(&mut self) -> PaletteBuffer {
         if let Some(buf) = &self.current_buffer {
             buf.clone()
         } else {
@@ -164,6 +159,15 @@ impl DynamicPaletteMem {
             self.current_buffer = Some(buf.clone());
             buf
         }
+    }*/
+
+    pub fn make_data(&mut self) -> Vec<PaletteColours> {
+        self.dirty = false;
+        self.bg_palettes.iter()
+            .map(|p| p.get_palette(true))
+            .chain(self.bg_palettes.iter().map(|p| p.get_palette(false)))
+            .chain(self.obj_palettes.iter().map(|p| p.get_palette(true)))
+            .collect::<Vec<_>>()
     }
 
     pub fn read_bg_index(&self) -> u8 {
@@ -198,7 +202,7 @@ impl DynamicPaletteMem {
             self.bg_palette_index = (self.bg_palette_index + 1) % 0x40;
         }
 
-        self.current_buffer = None;
+        self.dirty = true;
     }
 
     pub fn read_obj(&self) -> u8 {
@@ -215,6 +219,10 @@ impl DynamicPaletteMem {
             self.obj_palette_index = (self.obj_palette_index + 1) % 0x40;
         }
 
-        self.current_buffer = None;
+        self.dirty = true;
+    }
+
+    pub fn is_dirty(&self) -> bool {
+        self.dirty
     }
 }

--- a/src/video/mem/palette/mod.rs
+++ b/src/video/mem/palette/mod.rs
@@ -1,13 +1,2 @@
 pub mod dynamic;
 pub mod r#static;
-
-pub use crate::video::PaletteColours;
-
-use vulkano::{
-    buffer::cpu_pool::CpuBufferPoolChunk,
-    memory::pool::StdMemoryPool
-};
-
-use std::sync::Arc;
-
-pub type PaletteBuffer = CpuBufferPoolChunk<PaletteColours, Arc<StdMemoryPool>>;

--- a/src/video/mem/palette/static.rs
+++ b/src/video/mem/palette/static.rs
@@ -77,21 +77,6 @@ impl StaticPaletteMem {
         }
     }
 
-    /*pub fn get_buffer(&mut self) -> PaletteBuffer {
-        if let Some(buf) = &self.current_buffer {
-            buf.clone()
-        } else {
-            let buf = self.buffer_pool.chunk([
-                self.palettes[0].get_palette(true),     // BG
-                self.palettes[0].get_palette(false),    // Window
-                self.palettes[1].get_palette(true),     // Sprite 0
-                self.palettes[2].get_palette(true)      // Sprite 1
-            ].iter().cloned()).unwrap();
-            self.current_buffer = Some(buf.clone());
-            buf
-        }
-    }*/
-
     pub fn make_data(&mut self) -> Vec<PaletteColours> {
         self.dirty = false;
         vec![

--- a/src/video/mem/palette/static.rs
+++ b/src/video/mem/palette/static.rs
@@ -1,18 +1,8 @@
 // Game Boy and Super Game Boy 2-bit palettes.
-
-use vulkano::{
-    buffer::CpuBufferPool,
-    device::Device
-};
-
 use cgmath::{
     Matrix4,
     Vector4
 };
-
-use std::sync::Arc;
-
-use super::PaletteBuffer;
 
 use crate::video::{
     PaletteColours,
@@ -69,25 +59,25 @@ impl StaticPalette {
 
 // A group of palettes
 pub struct StaticPaletteMem {
-    palettes: Vec<StaticPalette>,
-    buffer_pool: CpuBufferPool<PaletteColours>,
-    current_buffer: Option<PaletteBuffer>
+    palettes:   Vec<StaticPalette>,
+
+    dirty:      bool
 }
 
 impl StaticPaletteMem {
-    pub fn new(device: &Arc<Device>, colours: SGBPalette) -> Self {
+    pub fn new(colours: SGBPalette) -> Self {
         StaticPaletteMem {
             palettes: vec![
                 StaticPalette::new(colours.bg),
                 StaticPalette::new(colours.obj0),
                 StaticPalette::new(colours.obj1)
             ],
-            buffer_pool: CpuBufferPool::uniform_buffer(device.clone()),
-            current_buffer: None
+
+            dirty:  true
         }
     }
 
-    pub fn get_buffer(&mut self) -> PaletteBuffer {
+    /*pub fn get_buffer(&mut self) -> PaletteBuffer {
         if let Some(buf) = &self.current_buffer {
             buf.clone()
         } else {
@@ -100,6 +90,16 @@ impl StaticPaletteMem {
             self.current_buffer = Some(buf.clone());
             buf
         }
+    }*/
+
+    pub fn make_data(&mut self) -> Vec<PaletteColours> {
+        self.dirty = false;
+        vec![
+            self.palettes[0].get_palette(true),       // BG
+            self.palettes[0].get_palette(false),    // Window
+            self.palettes[1].get_palette(true),     // Sprite 0
+            self.palettes[2].get_palette(true)      // Sprite 1
+        ]
     }
 
     pub fn get_colour_0(&self) -> Vector4<f32> {
@@ -113,6 +113,10 @@ impl StaticPaletteMem {
     pub fn write(&mut self, which: usize, val: u8) {
         self.palettes[which].write(val);
 
-        self.current_buffer = None;
+        self.dirty = true;
+    }
+
+    pub fn is_dirty(&self) -> bool {
+        self.dirty
     }
 }

--- a/src/video/mem/patternmem.rs
+++ b/src/video/mem/patternmem.rs
@@ -71,27 +71,7 @@ impl TileAtlas {
         })
     }
 
-    // Make an image from the atlas.
-    /*pub fn get_image(&mut self, device: &Arc<Device>, queue: &Arc<Queue>) -> (TileImage, TileFuture) {
-        if let Some(image) = &self.image {
-            (image.clone(), Box::new(now(device.clone())))
-        } else {
-            let width = (self.atlas_size.0 * TEX_WIDTH) as u32;
-            let height = (self.atlas_size.1 * TEX_HEIGHT) as u32;
-
-            let (image, future) = ImmutableImage::from_iter(
-                self.atlas.clone().into_iter(),
-                Dimensions::Dim2d { width: width, height: height },
-                R8Uint,
-                queue.clone()
-            ).expect("Couldn't create image.");
-
-            self.image = Some(image.clone());
-
-            (image, Box::new(future))
-        }
-    }*/
-
+    // Get the raw data and unset the dirty flag.
     pub fn ref_data<'a>(&'a mut self) -> &'a [u8] {
         self.dirty = false;
         &self.atlas
@@ -107,7 +87,7 @@ impl TileAtlas {
         [self.atlas_size.0 as f32, self.atlas_size.1 as f32]
     }
 
-    // Check if memory is dirty, and unset if it is.
+    // Check if memory is dirty.
     pub fn is_dirty(&self) -> bool {
         self.dirty
     }

--- a/src/video/mem/patternmem.rs
+++ b/src/video/mem/patternmem.rs
@@ -11,38 +11,13 @@
     // Each pixel is in reality, a 2-bit value mapped appropriately.
     // The fragment shader assigns the colour based on the value for the pixel.
 
-
-use vulkano::{
-    device::{
-        Device,
-        Queue
-    },
-    image::{
-        Dimensions,
-        immutable::ImmutableImage
-    },
-    format::{
-        R8Uint
-    },
-    sync::{
-        now, GpuFuture
-    }
-};
-
-use std::sync::Arc;
-
-const TEX_WIDTH: usize = 8;                     // Width of a tile in pixels.
-const TEX_HEIGHT: usize = 8;                    // Height of a tile in pixels.
-const TEX_AREA: usize = TEX_WIDTH * TEX_HEIGHT; // Area of a tile in total number of pixels.
-
-pub type TileImage = Arc<ImmutableImage<R8Uint>>;
-pub type TileFuture = Box<dyn GpuFuture>;
+use super::consts::TEX_AREA;
 
 pub struct TileAtlas {
     atlas:      Vec<u8>,            // formatted atlas of tiles
     atlas_size: (usize, usize),     // width/height of texture in tiles
-    
-    image:      Option<TileImage>   // cached images
+
+    dirty:      bool                // true if the data changes
 }
 
 impl TileAtlas {
@@ -52,7 +27,7 @@ impl TileAtlas {
             atlas:      vec![0; atlas_area],
             atlas_size: atlas_size,
 
-            image:      None,
+            dirty:      true,
         }
     }
 
@@ -65,7 +40,7 @@ impl TileAtlas {
             self.atlas[loc + i] = (self.atlas[loc + i] & bit!(1)) | bit;
         }
 
-        self.image = None;
+        self.dirty = true;
     }
 
     // The most significant bit.
@@ -76,7 +51,7 @@ impl TileAtlas {
             self.atlas[loc + i] = (self.atlas[loc + i] & bit!(0)) | (bit << 1);
         }
 
-        self.image = None;
+        self.dirty = true;
     }
 
     // Read a pixel row from the atlas.
@@ -97,7 +72,7 @@ impl TileAtlas {
     }
 
     // Make an image from the atlas.
-    pub fn get_image(&mut self, device: &Arc<Device>, queue: &Arc<Queue>) -> (TileImage, TileFuture) {
+    /*pub fn get_image(&mut self, device: &Arc<Device>, queue: &Arc<Queue>) -> (TileImage, TileFuture) {
         if let Some(image) = &self.image {
             (image.clone(), Box::new(now(device.clone())))
         } else {
@@ -115,6 +90,11 @@ impl TileAtlas {
 
             (image, Box::new(future))
         }
+    }*/
+
+    pub fn ref_data<'a>(&'a mut self) -> &'a [u8] {
+        self.dirty = false;
+        &self.atlas
     }
 
     // Get the size of a tile in the atlas.
@@ -125,5 +105,10 @@ impl TileAtlas {
     // Get the size of the atlas (in tiles).
     pub fn get_atlas_size(&self) -> [f32; 2] {
         [self.atlas_size.0 as f32, self.atlas_size.1 as f32]
+    }
+
+    // Check if memory is dirty, and unset if it is.
+    pub fn is_dirty(&self) -> bool {
+        self.dirty
     }
 }

--- a/src/video/mem/vertex/mod.rs
+++ b/src/video/mem/vertex/mod.rs
@@ -1,15 +1,6 @@
 pub mod sprite;
 pub mod tilemap;
 
-pub use super::super::types::Vertex;
-
-use vulkano::{
-    buffer::cpu_pool::CpuBufferPoolChunk,
-    memory::pool::StdMemoryPool
-};
-
-use std::sync::Arc;
-
 // Vertex data:
 // 0-7: Tile number
 // 8: Side
@@ -24,5 +15,3 @@ pub enum Side {
     Left     = 0 << 8,
     Right    = 1 << 8,
 }
-
-pub type VertexBuffer = CpuBufferPoolChunk<Vertex, Arc<StdMemoryPool>>;

--- a/src/video/mem/vertex/sprite.rs
+++ b/src/video/mem/vertex/sprite.rs
@@ -116,7 +116,7 @@ impl ObjectMem {
 
     // Gets vertices for a line.
     // Only retrieves the vertices that appear below the background.
-    pub fn get_lo_vertices<'a>(&'a mut self, y: u8, large: bool, cgb_mode: bool) -> &'a mut Vec<Vertex> {
+    pub fn ref_lo_vertices<'a>(&'a mut self, y: u8, large: bool, cgb_mode: bool) -> &'a mut Vec<Vertex> {
         self.buffer.clear();
 
         for o in self.objects.iter().rev() {
@@ -130,7 +130,7 @@ impl ObjectMem {
 
     // Gets vertices for a line.
     // Only retrieves the vertices that appear above the background.
-    pub fn get_hi_vertices<'a>(&'a mut self, y: u8, large: bool, cgb_mode: bool) -> &'a mut Vec<Vertex> {  // TODO: return mut vector?
+    pub fn ref_hi_vertices<'a>(&'a mut self, y: u8, large: bool, cgb_mode: bool) -> &'a mut Vec<Vertex> {  // TODO: return mut vector?
         self.buffer.clear();
 
         for o in self.objects.iter().rev() {

--- a/src/video/mem/vertex/sprite.rs
+++ b/src/video/mem/vertex/sprite.rs
@@ -1,18 +1,12 @@
 // Dealing with sprites.
-use vulkano::{
-    buffer::CpuBufferPool,
-    device::Device
-};
-
 use bitflags::bitflags;
 
-use crate::mem::MemDevice;
-
-use super::{
-    Side, Vertex, VertexBuffer
+use crate::{
+    mem::MemDevice,
+    video::types::Vertex
 };
 
-use std::sync::Arc;
+use super::Side;
 
 const SPRITE_SMALL_HEIGHT: u8 = 8;
 const SPRITE_LARGE_HEIGHT: u8 = 16;
@@ -106,25 +100,23 @@ impl Sprite {
 }
 
 pub struct ObjectMem {
-    objects:        Vec<Sprite>,
+    objects:    Vec<Sprite>,
 
-    buffer:         Vec<Vertex>,
-    buffer_pool:    CpuBufferPool<Vertex>,
+    buffer:     Vec<Vertex>,
 }
 
 impl ObjectMem {
-    pub fn new(device: &Arc<Device>) -> Self {
+    pub fn new() -> Self {
         ObjectMem {
-            objects:        vec![Sprite::new(); 40],
+            objects:    vec![Sprite::new(); 40],
 
-            buffer:         Vec::new(),
-            buffer_pool:    CpuBufferPool::vertex_buffer(device.clone())
+            buffer:     Vec::new()
         }
     }
 
     // Gets vertices for a line.
     // Only retrieves the vertices that appear below the background.
-    pub fn get_lo_vertex_buffer(&mut self, y: u8, large: bool, cgb_mode: bool) -> Option<VertexBuffer> {
+    pub fn get_lo_vertices<'a>(&'a mut self, y: u8, large: bool, cgb_mode: bool) -> &'a [Vertex] {
         self.buffer.clear();
 
         for o in self.objects.iter().rev() {
@@ -133,16 +125,17 @@ impl ObjectMem {
             }
         }
 
-        if self.buffer.is_empty() {
+        /*if self.buffer.is_empty() {
             None
         } else {
             Some(self.buffer_pool.chunk(self.buffer.drain(..)).unwrap())
-        }
+        }*/
+        &self.buffer
     }
 
     // Gets vertices for a line.
     // Only retrieves the vertices that appear above the background.
-    pub fn get_hi_vertex_buffer(&mut self, y: u8, large: bool, cgb_mode: bool) -> Option<VertexBuffer> {
+    pub fn get_hi_vertices<'a>(&'a mut self, y: u8, large: bool, cgb_mode: bool) -> &'a [Vertex] {  // TODO: return mut vector?
         self.buffer.clear();
 
         for o in self.objects.iter().rev() {
@@ -151,11 +144,12 @@ impl ObjectMem {
             }
         }
 
-        if self.buffer.is_empty() {
+        /*if self.buffer.is_empty() {
             None
         } else {
             Some(self.buffer_pool.chunk(self.buffer.drain(..)).unwrap())
-        }
+        }*/
+        &self.buffer
     }
 }
 

--- a/src/video/mem/vertex/sprite.rs
+++ b/src/video/mem/vertex/sprite.rs
@@ -125,11 +125,6 @@ impl ObjectMem {
             }
         }
 
-        /*if self.buffer.is_empty() {
-            None
-        } else {
-            Some(self.buffer_pool.chunk(self.buffer.drain(..)).unwrap())
-        }*/
         &self.buffer
     }
 
@@ -144,11 +139,6 @@ impl ObjectMem {
             }
         }
 
-        /*if self.buffer.is_empty() {
-            None
-        } else {
-            Some(self.buffer_pool.chunk(self.buffer.drain(..)).unwrap())
-        }*/
         &self.buffer
     }
 }

--- a/src/video/mem/vertex/sprite.rs
+++ b/src/video/mem/vertex/sprite.rs
@@ -116,7 +116,7 @@ impl ObjectMem {
 
     // Gets vertices for a line.
     // Only retrieves the vertices that appear below the background.
-    pub fn get_lo_vertices<'a>(&'a mut self, y: u8, large: bool, cgb_mode: bool) -> &'a [Vertex] {
+    pub fn get_lo_vertices<'a>(&'a mut self, y: u8, large: bool, cgb_mode: bool) -> &'a mut Vec<Vertex> {
         self.buffer.clear();
 
         for o in self.objects.iter().rev() {
@@ -125,12 +125,12 @@ impl ObjectMem {
             }
         }
 
-        &self.buffer
+        &mut self.buffer
     }
 
     // Gets vertices for a line.
     // Only retrieves the vertices that appear above the background.
-    pub fn get_hi_vertices<'a>(&'a mut self, y: u8, large: bool, cgb_mode: bool) -> &'a [Vertex] {  // TODO: return mut vector?
+    pub fn get_hi_vertices<'a>(&'a mut self, y: u8, large: bool, cgb_mode: bool) -> &'a mut Vec<Vertex> {  // TODO: return mut vector?
         self.buffer.clear();
 
         for o in self.objects.iter().rev() {
@@ -139,7 +139,7 @@ impl ObjectMem {
             }
         }
 
-        &self.buffer
+        &mut self.buffer
     }
 }
 

--- a/src/video/mem/vertex/tilemap.rs
+++ b/src/video/mem/vertex/tilemap.rs
@@ -15,22 +15,11 @@ bitflags! {
     }
 }
 
-#[derive(Clone)]
-enum BufferCache {
-    Buffer,                 // There exists a buffer that is not dirty.
-    Empty,                  // This data is intentionally empty.
-    Dirty                   // This data is dirty and must be recreated.
-}
-
 // Struct that contains the vertices to be used for rendering, in addition to the buffer pool.
 pub struct VertexGrid {
     vertices:           Vec<Vec<Vertex>>,
 
     dirty_lines:        Vec<bool>           // Indicates that a row is dirty (true) or unchanged (false).
-
-    //buffer_pool:        CpuBufferPool<Vertex>,
-    //lo_vertex_buffers:  Vec<BufferCache>,
-    //hi_vertex_buffers:  Vec<BufferCache>
 }
 
 impl VertexGrid {
@@ -75,10 +64,6 @@ impl VertexGrid {
         VertexGrid {
             vertices:       vertices,
             dirty_lines:    dirty_lines,
-
-            //buffer_pool:        CpuBufferPool::vertex_buffer(device.clone()),
-            //lo_vertex_buffers:  vertex_buffers.clone(),
-            //hi_vertex_buffers:  vertex_buffers
         }
     }
 
@@ -150,62 +135,14 @@ impl VertexGrid {
     }
 
     // Get a line of vertices.
-    // Only retrieves the vertices that appear below the objects.
-    // (This will get the whole background in GB mode).
     pub fn ref_data<'a>(&'a mut self, y: u8) -> &'a [Vertex] {
-        //let row = y as usize;
-        //let cached_buffer = &mut self.lo_vertex_buffers[row];
-        self.dirty_lines[y as usize] = false;
-        &self.vertices[y as usize]
+        let row = y as usize;
 
-        /*match cached_buffer {
-            BufferCache::Buffer(buffer) =>  Some(buffer.clone()),
-            BufferCache::Empty =>           None,
-            BufferCache::Dirty => {
-                let tile_map = self.vertices[row].iter()
-                    .cloned()
-                    .filter(|v| (v.data & BG_OAM_PRIORITY) == 0)
-                    .collect::<Vec<_>>();
-
-                if tile_map.is_empty() {
-                    *cached_buffer = BufferCache::Empty;
-                    None
-                } else {
-                    let buffer = self.buffer_pool.chunk(tile_map).unwrap();
-                    *cached_buffer = BufferCache::Buffer(buffer.clone());
-                    Some(buffer)
-                }
-            }
-        }*/
+        self.dirty_lines[row] = false;
+        &self.vertices[row]
     }
 
     pub fn is_dirty(&self, y: u8) -> bool {
         self.dirty_lines[y as usize]
     }
-
-    // Only retrieves the vertices that appear above the objects.
-    /*pub fn get_hi_vertex_buffer(&mut self, y: u8) -> Option<VertexBuffer> {
-        let row = y as usize;
-        let cached_buffer = &mut self.hi_vertex_buffers[row];
-
-        match cached_buffer {
-            BufferCache::Buffer(buffer) =>  Some(buffer.clone()),
-            BufferCache::Empty =>           None,
-            BufferCache::Dirty => {
-                let tile_map = self.vertices[row].iter()
-                    .cloned()
-                    .filter(|v| (v.data & BG_OAM_PRIORITY) != 0)
-                    .collect::<Vec<_>>();
-
-                if tile_map.is_empty() {
-                    *cached_buffer = BufferCache::Empty;
-                    None
-                } else {
-                    let buffer = self.buffer_pool.chunk(tile_map).unwrap();
-                    *cached_buffer = BufferCache::Buffer(buffer.clone());
-                    Some(buffer)
-                }
-            }
-        }
-    }*/
 }

--- a/src/video/mem/vertex/tilemap.rs
+++ b/src/video/mem/vertex/tilemap.rs
@@ -135,14 +135,12 @@ impl VertexGrid {
     }
 
     // Get a line of vertices.
-    pub fn ref_data<'a>(&'a mut self, y: u8) -> &'a [Vertex] {
-        let row = y as usize;
-
-        self.dirty_lines[row] = false;
-        &self.vertices[row]
+    pub fn ref_data<'a>(&'a mut self, y: usize) -> &'a [Vertex] {
+        self.dirty_lines[y] = false;
+        &self.vertices[y]
     }
 
-    pub fn is_dirty(&self, y: u8) -> bool {
-        self.dirty_lines[y as usize]
+    pub fn is_dirty(&self, y: usize) -> bool {
+        self.dirty_lines[y]
     }
 }

--- a/src/video/mod.rs
+++ b/src/video/mod.rs
@@ -14,8 +14,6 @@ mod constants {
     pub const FRAME_CYCLE: u32  = 144 * H_CYCLES;   // Time spent cycling through modes 2,3 and 0 before V-Blank
 }
 
-use cgmath::Matrix4;
-
 use crate::interrupt::InterruptFlags;
 use crate::mem::MemDevice;
 
@@ -24,13 +22,12 @@ use self::sgbpalettes::SGBPalette;
 pub use self::vulkan::VulkanRenderer;
 
 pub use self::types::{
+    PaletteColours,
     Renderer,
-    WindowType
+    RendererType
 };
 
 pub use sgbpalettes::UserPalette;
-
-pub type PaletteColours = Matrix4<f32>;
 
 // Modes
 #[derive(PartialEq, Debug, Clone, Copy)]
@@ -61,8 +58,12 @@ pub struct VideoDevice {
 }
 
 impl VideoDevice {
-    pub fn new(mut renderer: Box<VulkanRenderer>, palette: SGBPalette, cgb_mode: bool) -> Self {
-        let mut mem = VideoMem::new(&renderer.get_device(), palette, cgb_mode);
+    pub fn new(renderer_type: RendererType, palette: SGBPalette, cgb_mode: bool) -> Self {
+        let mut mem = VideoMem::new(palette, cgb_mode);
+
+        let mut renderer = match renderer_type {
+            RendererType::Vulkano(e) => VulkanRenderer::new(e, &mem)
+        };
 
         renderer.frame_start(&mut mem);
 

--- a/src/video/types.rs
+++ b/src/video/types.rs
@@ -1,9 +1,4 @@
-use winit::{
-    EventsLoop,
-    Window
-};
-
-use std::ffi::c_void;
+use winit::EventsLoop;
 
 use super::mem::VideoMem;
 
@@ -13,6 +8,8 @@ pub struct Vertex {
     pub data: u32
 }
 
+pub type PaletteColours = cgmath::Matrix4<f32>;
+
 pub trait Renderer {
     fn frame_start(&mut self, video_mem: &mut VideoMem);
     fn frame_end(&mut self);
@@ -21,14 +18,6 @@ pub trait Renderer {
     fn on_resize(&mut self);
 }
 
-pub enum WindowType<'a> {
-    Winit(&'a EventsLoop),
-    IOS {
-        ui_view:    *const c_void,
-        window:     Window
-    },
-    MacOS {
-        ns_view:    *const c_void,
-        window:     Window
-    }
+pub enum RendererType<'a> {
+    Vulkano(&'a EventsLoop)
 }

--- a/src/video/vulkan/memadapter.rs
+++ b/src/video/vulkan/memadapter.rs
@@ -1,0 +1,211 @@
+// Wraps the raw memory for vulkan.
+
+use vulkano::{
+    device::{
+        Device,
+        Queue
+    },
+    image::{
+        Dimensions,
+        immutable::ImmutableImage
+    },
+    format::{
+        R8Uint
+    },
+    sync::{
+        now, GpuFuture
+    },
+    buffer::{
+        CpuBufferPool,
+        cpu_pool::CpuBufferPoolChunk
+    },
+    memory::pool::StdMemoryPool
+};
+
+use std::sync::Arc;
+
+use crate::video::{
+    PaletteColours,
+    types::Vertex,
+    mem::{
+        VideoMem,
+        consts::{TEX_WIDTH, TEX_HEIGHT, MAP_SIZE}
+    }
+};
+
+const BG_OAM_PRIORITY: u32 = 1 << 19;
+
+// Memory types.
+pub type TileImage = Arc<ImmutableImage<R8Uint>>;
+pub type TileFuture = Box<dyn GpuFuture>;
+pub type VertexBuffer = CpuBufferPoolChunk<Vertex, Arc<StdMemoryPool>>;
+pub type PaletteBuffer = CpuBufferPoolChunk<PaletteColours, Arc<StdMemoryPool>>;
+
+pub struct MemAdapter {
+    // Image for tile pattern memory
+    image:                  Option<TileImage>,
+    atlas_size:             (usize, usize),
+
+    // Vertex buffers for tile map & sprites
+    vertex_buffer_pool:     CpuBufferPool<Vertex>,
+    lo_vertex_buffers:      Vec<Option<VertexBuffer>>,
+    hi_vertex_buffers:      Vec<Option<VertexBuffer>>,
+
+    // Buffers for palettes
+    palette_buffer_pool:    CpuBufferPool<PaletteColours>,
+    current_palette_buffer: Option<PaletteBuffer>
+}
+
+impl MemAdapter {
+    pub fn new(mem: &VideoMem, device: &Arc<Device>) -> Self {
+        let atlas_size = mem.get_atlas_size();
+
+        let vertex_buffers = vec![None; MAP_SIZE * TEX_HEIGHT];   // TODO: deal with this const.
+
+        MemAdapter {
+            image:                  None,
+            atlas_size:             (atlas_size[0] as usize, atlas_size[1] as usize),
+
+            vertex_buffer_pool:     CpuBufferPool::vertex_buffer(device.clone()),
+            lo_vertex_buffers:      vertex_buffers.clone(),
+            hi_vertex_buffers:      vertex_buffers,
+
+            palette_buffer_pool:    CpuBufferPool::uniform_buffer(device.clone()),
+            current_palette_buffer: None
+        }
+    }
+
+    // Make an image from the pattern memory.
+    pub fn get_image(&mut self, mem: &mut VideoMem, device: &Arc<Device>, queue: &Arc<Queue>) -> (TileImage, TileFuture) {
+        if let Some(data) = mem.ref_tile_atlas() {
+            let width = (self.atlas_size.0 * TEX_WIDTH) as u32;
+            let height = (self.atlas_size.1 * TEX_HEIGHT) as u32;
+
+            let (image, future) = ImmutableImage::from_iter(
+                data.iter().cloned(),
+                Dimensions::Dim2d { width: width, height: height },
+                R8Uint,
+                queue.clone()
+            ).expect("Couldn't create image.");
+
+            self.image = Some(image.clone());
+
+            (image, Box::new(future))
+        } else if let Some(image) = &self.image {
+            (image.clone(), Box::new(now(device.clone())))
+        } else {
+            // TODO: make this a bit cleaner.
+            panic!("No dirty pattern memory or image!");
+        }
+    }
+
+    // Get background vertices for given y line.
+    pub fn get_background(&mut self, mem: &mut VideoMem, y: u8) -> Option<VertexBuffer> {
+        if mem.is_cgb_mode() || mem.get_background_priority() {
+            self.get_lo_vertex_buffer(mem.ref_background(y), y)
+        } else {
+            None
+        }
+    }
+
+    // Get background vertices with priority bit set for given y line.
+    pub fn get_background_hi(&mut self, mem: &mut VideoMem, y: u8) -> Option<VertexBuffer> {
+        if mem.is_cgb_mode() {
+            self.get_hi_vertex_buffer(mem.ref_background(y), y)
+        } else {
+            None
+        }
+    }
+
+    // Get window vertices for given y line.
+    pub fn get_window(&mut self, mem: &mut VideoMem, y: u8) -> Option<VertexBuffer> {
+        if mem.get_window_priority() {
+            self.get_lo_vertex_buffer(mem.ref_window(y), y)
+        } else {
+            None
+        }
+    }
+
+    // Get window vertices with priority bit set for given y line.
+    pub fn get_window_hi(&mut self, mem: &mut VideoMem, y: u8) -> Option<VertexBuffer> {
+        if mem.is_cgb_mode() {
+            self.get_hi_vertex_buffer(mem.ref_window(y), y)
+        } else {
+            None
+        }
+    }
+
+    // Get low-priority sprites (below the background) for given y line.
+    pub fn get_sprites_lo(&mut self, mem: &mut VideoMem, y: u8) -> Option<VertexBuffer> {
+        mem.ref_sprites_lo(y).and_then(|vertices| Some(self.vertex_buffer_pool.chunk(vertices.iter().cloned()).unwrap()))
+    }
+
+    // Get high-priority sprites (above the background) for given y line.
+    pub fn get_sprites_hi(&mut self, mem: &mut VideoMem, y: u8) -> Option<VertexBuffer> {
+        mem.ref_sprites_hi(y).and_then(|vertices| Some(self.vertex_buffer_pool.chunk(vertices.iter().cloned()).unwrap()))
+    }
+
+    // Get palettes
+    pub fn get_palette_buffer(&mut self, mem: &mut VideoMem) -> PaletteBuffer {
+        if let Some(palettes) = mem.make_palettes() {
+            let buf = self.palette_buffer_pool.chunk(
+                palettes.into_iter()
+            ).unwrap();
+            self.current_palette_buffer = Some(buf.clone());
+            buf
+        } else if let Some(buf) = &self.current_palette_buffer {
+            buf.clone()
+        } else {
+            panic!("Cannot find palette buffer!");
+        }
+    }
+}
+
+// Internal
+impl MemAdapter {
+    fn get_lo_vertex_buffer(&mut self, buffer: Option<&[Vertex]>, y: u8) -> Option<VertexBuffer> {
+        let row = y as usize;
+        let cached_buffer = &mut self.lo_vertex_buffers[row];
+
+        if let Some(data) = buffer {
+            let tile_map = data.iter()
+                .cloned()
+                .filter(|v| (v.data & BG_OAM_PRIORITY) == 0)
+                .collect::<Vec<_>>();
+
+            if tile_map.is_empty() {
+                *cached_buffer = None;
+                None
+            } else {
+                let buffer = Some(self.vertex_buffer_pool.chunk(tile_map).unwrap());
+                *cached_buffer = buffer.clone();
+                buffer
+            }
+        } else {
+            cached_buffer.clone()
+        }
+    }
+
+    fn get_hi_vertex_buffer(&mut self, buffer: Option<&[Vertex]>, y: u8) -> Option<VertexBuffer> {
+        let row = y as usize;
+        let cached_buffer = &mut self.hi_vertex_buffers[row];
+
+        if let Some(data) = buffer {
+            let tile_map = data.iter()
+                .cloned()
+                .filter(|v| (v.data & BG_OAM_PRIORITY) != 0)
+                .collect::<Vec<_>>();
+
+            if tile_map.is_empty() {
+                *cached_buffer = None;
+                None
+            } else {
+                let buffer = Some(self.vertex_buffer_pool.chunk(tile_map).unwrap());
+                *cached_buffer = buffer.clone();
+                buffer
+            }
+        } else {
+            cached_buffer.clone()
+        }
+    }
+}

--- a/src/video/vulkan/memadapter.rs
+++ b/src/video/vulkan/memadapter.rs
@@ -136,12 +136,12 @@ impl MemAdapter {
 
     // Get low-priority sprites (below the background) for given y line.
     pub fn get_sprites_lo(&mut self, mem: &mut VideoMem, y: u8) -> Option<VertexBuffer> {
-        mem.ref_sprites_lo(y).and_then(|vertices| Some(self.vertex_buffer_pool.chunk(vertices.iter().cloned()).unwrap()))
+        mem.ref_sprites_lo(y).and_then(|vertices| Some(self.vertex_buffer_pool.chunk(vertices.drain(..)).unwrap()))
     }
 
     // Get high-priority sprites (above the background) for given y line.
     pub fn get_sprites_hi(&mut self, mem: &mut VideoMem, y: u8) -> Option<VertexBuffer> {
-        mem.ref_sprites_hi(y).and_then(|vertices| Some(self.vertex_buffer_pool.chunk(vertices.iter().cloned()).unwrap()))
+        mem.ref_sprites_hi(y).and_then(|vertices| Some(self.vertex_buffer_pool.chunk(vertices.drain(..)).unwrap()))
     }
 
     // Get palettes

--- a/src/video/vulkan/memadapter.rs
+++ b/src/video/vulkan/memadapter.rs
@@ -28,7 +28,6 @@ use crate::video::{
     PaletteColours,
     types::Vertex,
     mem::{
-        TileMap,
         VideoMem,
         consts::{TEX_WIDTH, TEX_HEIGHT, MAP_SIZE}
     }
@@ -107,10 +106,7 @@ impl MemAdapter {
     pub fn get_background(&mut self, mem: &mut VideoMem, y: u8) -> Option<VertexBuffer> {
         if mem.is_cgb_mode() || mem.get_background_priority() {
             let row = y as usize;
-            let vertices = match mem.background_tile_map() {
-                TileMap::_0 => mem.ref_tile_map_0(row),
-                TileMap::_1 => mem.ref_tile_map_1(row)
-            };
+            let vertices = mem.ref_background(row);
             Self::make_lo_vertex_buffer(vertices, &mut self.vertex_buffer_pool, &mut self.lo_bg_vertex_buffers[row])
         } else {
             None
@@ -121,10 +117,7 @@ impl MemAdapter {
     pub fn get_background_hi(&mut self, mem: &mut VideoMem, y: u8) -> Option<VertexBuffer> {
         if mem.is_cgb_mode() {
             let row = y as usize;
-            let vertices = match mem.background_tile_map() {
-                TileMap::_0 => mem.ref_tile_map_0(row),
-                TileMap::_1 => mem.ref_tile_map_1(row)
-            };
+            let vertices = mem.ref_background(row);
             Self::make_hi_vertex_buffer(vertices, &mut self.vertex_buffer_pool, &mut self.hi_bg_vertex_buffers[row])
         } else {
             None
@@ -135,10 +128,7 @@ impl MemAdapter {
     pub fn get_window(&mut self, mem: &mut VideoMem, y: u8) -> Option<VertexBuffer> {
         if mem.get_window_enable() {
             let row = y as usize;
-            let vertices = match mem.window_tile_map() {
-                TileMap::_0 => mem.ref_tile_map_0(row),
-                TileMap::_1 => mem.ref_tile_map_1(row)
-            };
+            let vertices = mem.ref_window(row);
             Self::make_lo_vertex_buffer(vertices, &mut self.vertex_buffer_pool, &mut self.lo_window_vertex_buffers[row])
         } else {
             None
@@ -149,10 +139,7 @@ impl MemAdapter {
     pub fn get_window_hi(&mut self, mem: &mut VideoMem, y: u8) -> Option<VertexBuffer> {
         if mem.is_cgb_mode() {
             let row = y as usize;
-            let vertices = match mem.window_tile_map() {
-                TileMap::_0 => mem.ref_tile_map_0(row),
-                TileMap::_1 => mem.ref_tile_map_1(row)
-            };
+            let vertices = mem.ref_window(row);
             Self::make_hi_vertex_buffer(vertices, &mut self.vertex_buffer_pool, &mut self.hi_window_vertex_buffers[row])
         } else {
             None

--- a/src/video/vulkan/mod.rs
+++ b/src/video/vulkan/mod.rs
@@ -1,4 +1,5 @@
 mod renderer;
 mod shaders;
+mod memadapter;
 
 pub use renderer::VulkanRenderer;


### PR DESCRIPTION
Decoupled vulkano from video memory. This will allow other graphics APIs to be used for rendering in the future.

Introduces `MemAdapter`, which reads from `VideoMem` and wraps the data in vulkano GPU data structures.

Also removed "windowtype" as it has become clear that other methods will be needed for rendering for iOS.