### PR TITLE
External Audio Handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustboy"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["coopersimon <simon.d.cooper@hotmail.co.uk>"]
 edition = "2018"
 
@@ -12,7 +12,6 @@ path = "src/lib.rs"
 debug = []
 
 [dependencies]
-cpal = "0.11"
 bitflags = "1.1"
 chrono = "0.4"
 crossbeam-channel = "0.4.2"

--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -14,10 +14,7 @@ use noise::NoiseRegs;
 
 use crate::mem::MemDevice;
 
-use crossbeam_channel::{
-    Sender,
-    Receiver
-};
+use crossbeam_channel::Sender;
 
 pub use handler::AudioHandler;
 
@@ -41,7 +38,6 @@ pub struct AudioDevice {
     update:          bool,
     control_update:  bool,
     sender:          Option<Sender<AudioCommand>>,
-    //reply_recv:      Option<Receiver<()>>,
 
     cycle_count:     u32,
 }
@@ -61,7 +57,6 @@ impl AudioDevice {
             update:         false,
             control_update: false,
             sender:         None,
-            //reply_recv:     None,
 
             cycle_count:    0,
         }

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -1,11 +1,15 @@
 // CPU Module
 use bitflags::bitflags;
+use crossbeam_channel::Sender;
 
-use crate::mem::{MemBus, MemDevice};
-use crate::interrupt::*;
-use crate::joypad::{
-    Buttons,
-    Directions
+use crate::{
+    audio::AudioCommand,
+    mem::{MemBus, MemDevice},
+    interrupt::*,
+    joypad::{
+        Buttons,
+        Directions
+    }
 };
 
 use std::sync::{
@@ -159,8 +163,12 @@ impl CPU {
     }
 
     pub fn frame_update(&mut self, frame: Arc<Mutex<[u8]>>) {
-        self.mem.render_frame(frame);
+        self.mem.frame(frame);
         self.mem.flush_cart();
+    }
+
+    pub fn enable_audio(&mut self, sender: Sender<AudioCommand>) {
+        self.mem.enable_audio(sender);
     }
 
     pub fn set_button(&mut self, button: Buttons, val: bool) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,15 +26,10 @@ use std::sync::{
     Mutex
 };
 
-use crossbeam_channel::{
-    unbounded, Receiver
-};
+use crossbeam_channel::unbounded;
 
 use cpu::CPU;
-use audio::{
-    AudioCommand,
-    AudioHandler
-};
+use audio::AudioHandler;
 use mem::MemBus;
 
 pub const FRAME_SIZE_BYTES: usize = 160 * 144 * 4;
@@ -58,14 +53,8 @@ pub struct RustBoy {
 
 impl RustBoy {
     pub fn new(cart_name: &str, save_file_name: &str, palette: UserPalette) -> Box<Self> {
-        //let ad = AudioDevice::new(audio_send, audio_reply_recv);
         let mem = MemBus::new(cart_name, save_file_name, palette);
-
         let cpu = CPU::new(mem);
-
-        //let audio_packet = Arc::new(Mutex::new(vec![0.0; sample_rate / 60]));
-
-        //start_audio_handler_thread(audio_recv, audio_reply, sample_rate, audio_packet.clone());
 
         Box::new(RustBoy {
             cpu:            cpu,


### PR DESCRIPTION
Moved all of the cpal stuff outside the rustboy core. Now, the audio process is as follows:

First, to enable audio, call "enable audio" on the rustboy. This provides you with a RustBoyAudioHandler. This can then be polled (on a separate thread if you want) to extract arbitrary amounts of audio data.

Warning: if you poll it extremely quickly it will probably wait for the video/main thread to catch up.